### PR TITLE
Fix for parsing content with -- inside

### DIFF
--- a/Sources/Multipart/BoundaryParser.swift
+++ b/Sources/Multipart/BoundaryParser.swift
@@ -43,8 +43,7 @@ final class BoundaryParser {
             let match = [.hyphen, .hyphen] + boundary
             
             if
-                (buffer.count <= 1 && byte == .hyphen) ||
-                    (buffer.count > 1 && buffer.count < match.count)
+                buffer.count < match.count && match[buffer.count] == byte
             {
                 state = .parsing(buffer: buffer + [byte], trailingHyphenCount: trailingHyphenCount)
                 break main

--- a/Tests/FormDataTests/ParserTests.swift
+++ b/Tests/FormDataTests/ParserTests.swift
@@ -8,7 +8,8 @@ class ParserTests: XCTestCase {
         ("testFormData", testFormData),
         ("testWebkit", testWebkit),
         ("testForm", testForm),
-        ("testFormManyFields", testFormManyFields)
+        ("testFormManyFields", testFormManyFields),
+        ("testBoundaryLikeContent", testBoundaryLikeContent)
     ]
 
     func testFormData() throws {
@@ -138,5 +139,30 @@ class ParserTests: XCTestCase {
         for i in 1...5 {
             XCTAssertEqual(fields["field\(i)"]?.part.body.makeString(), "The Quick Brown Fox Jumps Over The Lazy Dog", "Field 'field\(i)' was parsed incorrectly!")
         }
+    }
+    
+    func testBoundaryLikeContent() throws {
+        var message = ""
+        
+        message += "------WebKitFormBoundaryezkRLRyEVe1aMUVZ\r\n"
+        message += "Content-Disposition: form-data; name=\"file\"; filename=\"test.txt\"\r\n"
+        message += "Content-Type: text/plain\r\n"
+        message += "\r\n"
+        message += "---this is a test\r\n"
+        message += "------WebKitFormBoundaryezkRLRyEVe1aMUVZ--\r\n"
+        
+        let multipart = try Multipart.Parser(boundary: "----WebKitFormBoundaryezkRLRyEVe1aMUVZ")
+        let parser = FormData.Parser(multipart: multipart)
+        
+        var fields: [String: Field] = [:]
+        
+        parser.onField = { field in
+            fields[field.name] = field
+        }
+        
+        try parser.multipart.parse(message)
+        
+        XCTAssertEqual(fields["file"]?.filename, "test.txt")
+        XCTAssertEqual("---this is a test", fields["file"]?.part.body.string)
     }
 }

--- a/Tests/FormDataTests/ParserTests.swift
+++ b/Tests/FormDataTests/ParserTests.swift
@@ -163,6 +163,6 @@ class ParserTests: XCTestCase {
         try parser.multipart.parse(message)
         
         XCTAssertEqual(fields["file"]?.filename, "test.txt")
-        XCTAssertEqual("---this is a test", fields["file"]?.part.body.string)
+        XCTAssertEqual("---this is a test", fields["file"]?.part.body.makeString())
     }
 }


### PR DESCRIPTION
This is a reproduction of vapor/vapor#938.

The boundary parser seems to throw away the whole content if it contains `--` (the start of a boundary) after reading in `boundary.count` bytes. If the content is shorter than the boundary, the ending boundary is half read into memory, then ignored as well.