### PR TITLE
Allow quotes around boundary value in multipart/form-data Content-Type header

### DIFF
--- a/Sources/Multipart/Parser.swift
+++ b/Sources/Multipart/Parser.swift
@@ -73,11 +73,17 @@ public final class Parser {
     
     /// Extracts the boundary from a multipart Content-Type header
     public static func extractBoundary(contentType: BytesConvertible) throws -> Bytes {
-        let boundaryPieces = try contentType.makeBytes().makeString().components(separatedBy: "boundary=")
-        guard boundaryPieces.count == 2 else {
-            throw Error.invalidBoundary
-        }
-        return boundaryPieces[1].makeBytes()
+        let contentTypeString = try contentType.makeBytes().makeString()
+		guard let boundaryEndIndex = contentTypeString.range(of: "boundary=")?.upperBound else { throw Error.invalidBoundary }
+		
+		var boundaryRange = boundaryEndIndex ..< contentTypeString.endIndex
+		if contentTypeString[boundaryRange].hasPrefix("\"") {
+			if !contentTypeString[boundaryRange].hasSuffix("\"") { throw Error.invalidBoundary } 
+			
+			boundaryRange = contentTypeString.index(boundaryRange.lowerBound, offsetBy: 1) ..< contentTypeString.index(boundaryRange.upperBound, offsetBy: -1) 
+		}
+		
+		return String(contentTypeString[boundaryRange]).makeBytes()
     }
     
     /// Create a new multipart parser from a 

--- a/Tests/MultipartTests/ParserTests.swift
+++ b/Tests/MultipartTests/ParserTests.swift
@@ -188,4 +188,16 @@ class ParserTests: XCTestCase {
         
         XCTAssertEqual(parts.count, 3)
     }
+	
+	func testExtractBoundary() throws {
+		let contentTypeValue = "multipart/form-data; boundary=asdf"
+		
+		XCTAssertEqual(try Parser.extractBoundary(contentType: contentTypeValue), "asdf".makeBytes())
+	}
+	
+	func testExtractBoundaryWithQuotes() throws {
+		let contentTypeValue = "multipart/form-data; boundary=\"asdf\""
+		
+		XCTAssertEqual(try Parser.extractBoundary(contentType: contentTypeValue), "asdf".makeBytes())
+	}
 }

--- a/Tests/MultipartTests/ParserTests.swift
+++ b/Tests/MultipartTests/ParserTests.swift
@@ -195,6 +195,7 @@ class ParserTests: XCTestCase {
 		XCTAssertEqual(try Parser.extractBoundary(contentType: contentTypeValue), "asdf".makeBytes())
 	}
 	
+	/// Quotes around boundary is allowed in the HTTP spec, see https://tools.ietf.org/html/rfc7231#section-3.1.1.1
 	func testExtractBoundaryWithQuotes() throws {
 		let contentTypeValue = "multipart/form-data; boundary=\"asdf\""
 		


### PR DESCRIPTION
Currently the form data parsing fails completely if there's quotes around the boundary value in the Content-Type header (e.g. `Content-Type: multipart/form-data; boundary="asdf"`). This adds support for this in the parser and adds tests of the extractBoundary method, which didn't exist before.