### PR TITLE
Add Content-Type to responses

### DIFF
--- a/Sources/Multipart/MultipartPart.swift
+++ b/Sources/Multipart/MultipartPart.swift
@@ -18,9 +18,6 @@ public struct MultipartPart {
             }
             value.parameters["filename"] = newValue
             contentDisposition = value
-            if let filename = filename, let fileExt = filename.components(separatedBy: ".").last {
-                contentType = MediaType.fileExtension(fileExt)
-            }
         }
     }
 

--- a/Sources/Multipart/MultipartPart.swift
+++ b/Sources/Multipart/MultipartPart.swift
@@ -18,6 +18,9 @@ public struct MultipartPart {
             }
             value.parameters["filename"] = newValue
             contentDisposition = value
+            if let filename = filename, let fileExt = filename.components(separatedBy: ".").last {
+                contentType = MediaType.fileExtension(fileExt)
+            }
         }
     }
 

--- a/Sources/Multipart/MultipartPartConvertible.swift
+++ b/Sources/Multipart/MultipartPartConvertible.swift
@@ -84,6 +84,7 @@ extension File: MultipartPartConvertible {
     public func convertToMultipartPart() throws -> MultipartPart {
         var part = MultipartPart(data: data)
         part.filename = filename
+        part.contentType = contentType
         return part
     }
 


### PR DESCRIPTION
Related to #20 

Why does NIO add headers in lowercase 😢 

-------

The test that doesn't pass is a false positive: https://github.com/vapor/vapor/blob/master/Tests/VaporTests/ApplicationTests.swift#L289

Compares

> age=3&luckyNumbers[]=5&luckyNumbers[]=7&name=Vapor
with
> name=Vapor&age=3&luckyNumbers[]=5&luckyNumbers[]=7

They have the same encoded values but in different order (doesn't matter).
_Possible_ reason: Attributes are ordered alphabetically ?