### PR TITLE
Implement [File] encoding

### DIFF
--- a/Sources/Multipart/FormDataEncoder.swift
+++ b/Sources/Multipart/FormDataEncoder.swift
@@ -50,6 +50,12 @@ private final class FormDataEncoderContext {
         }
         parts.append(part)
     }
+    
+    func encode(_ files: [File], at codingPath: [CodingKey]) throws {
+        for file in files {
+            try encode(file, at: codingPath)
+        }
+    }
 }
 
 private struct _FormDataEncoder: Encoder {
@@ -110,6 +116,8 @@ private struct _FormDataKeyedEncoder<K>: KeyedEncodingContainerProtocol where K:
 
     mutating func encode<T>(_ value: T, forKey key: K) throws where T : Encodable {
         if value is MultipartPartConvertible {
+            try multipart.encode(value, at: codingPath + [key])
+        } else if let value = value as? [File] {
             try multipart.encode(value, at: codingPath + [key])
         } else {
             let encoder = _FormDataEncoder(multipart: multipart, codingPath: codingPath + [key])

--- a/Tests/MultipartTests/MultipartTests.swift
+++ b/Tests/MultipartTests/MultipartTests.swift
@@ -85,27 +85,27 @@ class MultipartTests: XCTestCase {
         let data = try FormDataEncoder().encode(a, boundary: "hello")
         XCTAssertEqual(data.utf8, """
         --hello\r
-        Content-Disposition: form-data; name=string\r
+        Content-Disposition: form-data; name="string"\r
         \r
         a\r
         --hello\r
-        Content-Disposition: form-data; name=int\r
+        Content-Disposition: form-data; name="int"\r
         \r
         42\r
         --hello\r
-        Content-Disposition: form-data; name=double\r
+        Content-Disposition: form-data; name="double"\r
         \r
         3.14\r
         --hello\r
-        Content-Disposition: form-data; name=array[]\r
+        Content-Disposition: form-data; name="array[]"\r
         \r
         1\r
         --hello\r
-        Content-Disposition: form-data; name=array[]\r
+        Content-Disposition: form-data; name="array[]"\r
         \r
         2\r
         --hello\r
-        Content-Disposition: form-data; name=array[]\r
+        Content-Disposition: form-data; name="array[]"\r
         \r
         3\r
         --hello--\r


### PR DESCRIPTION
I tried to send POST request with `formData` with one file like this
```swift
struct Payload: Codable {
    var key1: String
    var attachment: File
}
```
and it works perfectly, but when I tried to send multiple files like this
```swift
struct Payload: Codable {
    var key1: String
    var attachment: [File]
}
```
it throws an error
`⚠️ [MultipartError.nestedEncode: Nesting is not supported when encoding multipart data.]`

While debugging this issue I found a way how to encode [File] array, and it works perfectly!
I need this functionality in a various of projects and especially in @twof 's Mailgun lib so I hope that this PR will be merged.