### PR TITLE
MultipartPartDecodable initialized with associatedtype Body

### DIFF
--- a/Sources/MultipartKit/FormDataDecoder/FormDataDecoder+SingleValueContainer.swift
+++ b/Sources/MultipartKit/FormDataDecoder/FormDataDecoder+SingleValueContainer.swift
@@ -93,7 +93,7 @@ extension FormDataDecoder.Decoder: SingleValueDecodingContainer {
 
         let decoded =
             switch T.self {
-            case let multipartDecodable as any MultipartPartDecodable.Type:
+            case let multipartDecodable as any MultipartPartDecodable<Body>.Type:
                 try multipartDecodable.init(multipart: part) as? T
             case is MultipartPart<Body>.Type:
                 part as? T

--- a/Sources/MultipartKit/MultipartPartConvertible.swift
+++ b/Sources/MultipartKit/MultipartPartConvertible.swift
@@ -6,10 +6,10 @@ public protocol MultipartPartEncodable<Body> {
 }
 
 /// A type that can be converted from a `MultipartPart`.
-public protocol MultipartPartDecodable {
+public protocol MultipartPartDecodable<Body> {
     associatedtype Body: MultipartPartBodyElement
 
-    init(multipart: MultipartPart<some MultipartPartBodyElement>) throws
+    init(multipart: MultipartPart<Body>) throws
 }
 
 /// A type that can be converted to and from a `MultipartPart`.

--- a/Tests/MultipartKitTests/FormDataDecodingTests.swift
+++ b/Tests/MultipartKitTests/FormDataDecodingTests.swift
@@ -356,7 +356,7 @@ struct FormDataDecodingTests {
             age: 4,
             image: File(filename: "droplet.png", data: Array("<contents of image>".utf8)))
 
-        let message = ArraySlice(
+        let message = Array(
             """
             --helloBoundary\r
             Content-Disposition: form-data; name="name"\r

--- a/Tests/MultipartKitTests/Utilities/File.swift
+++ b/Tests/MultipartKitTests/Utilities/File.swift
@@ -4,7 +4,7 @@ struct File: Codable, Equatable, MultipartPartConvertible {
     typealias Body = [UInt8]
 
     let filename: String
-    let data: [UInt8]
+    let data: Body
 
     enum MultipartError: Error {
         case invalidFileName
@@ -21,7 +21,7 @@ struct File: Codable, Equatable, MultipartPartConvertible {
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let data = try container.decode([UInt8].self, forKey: .data)
+        let data = try container.decode(Body.self, forKey: .data)
         let filename = try container.decode(String.self, forKey: .filename)
         self.init(filename: filename, data: data)
     }
@@ -32,7 +32,7 @@ struct File: Codable, Equatable, MultipartPartConvertible {
         try container.encode(self.filename, forKey: .filename)
     }
 
-    var multipart: MultipartPart<[UInt8]> {
+    var multipart: MultipartPart<Body> {
         let part = MultipartPart(
             headerFields: [.contentDisposition: "form-data; name=\"image\"; filename=\"\(filename)\""],
             body: self.data
@@ -40,7 +40,7 @@ struct File: Codable, Equatable, MultipartPartConvertible {
         return part
     }
 
-    init(multipart: MultipartPart<some MultipartPartBodyElement>) throws {
+    init(multipart: MultipartPart<Body>) throws {
         let contentDisposition = multipart.headerFields[.contentDisposition] ?? ""
         let filenamePattern = "filename=\"([^\"]+)\""
         let filename: String
@@ -54,6 +54,6 @@ struct File: Codable, Equatable, MultipartPartConvertible {
             throw MultipartError.invalidFileName
         }
 
-        self.init(filename: filename, data: Array(multipart.body))
+        self.init(filename: filename, data: multipart.body)
     }
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Use associatedtype `Body` in initialiser for `MultipartPartDecodable`. This also required setting this as the primary associated type so we can cast to it in `FormDataDecoder`.  This required tests to also be updated so the same buffer type was used in the `File` type and the test `decodeSimilVaporFileType` that used it.

<!-- When this PR is merged, the title and body will be -->

Use associatedtype `Body` in initialiser for `MultipartPartDecodable`

<!-- used to generate a release automatically. -->
