### PR TITLE
Add `FormDataEncoder.encode(_:,boundary:,into:)`

### DIFF
--- a/Sources/MultipartKit/FormDataEncoder/FormDataEncoder.swift
+++ b/Sources/MultipartKit/FormDataEncoder/FormDataEncoder.swift
@@ -37,14 +37,13 @@ public struct FormDataEncoder: Sendable {
     ///
     /// ```swift
     /// let a = Foo(string: "a", int: 42, double: 3.14, array: [1, 2, 3])
-    /// var buffer = ByteBuffer()
-    /// let data = try FormDataEncoder().encode(a, boundary: "123", into: &buffer)
+    /// let data: [UInt8] = try FormDataEncoder().encode(a, boundary: "123")
     /// ```
     ///
     /// - parameters:
     ///     - encodable: Generic `Encodable` item.
     ///     - boundary: Multipart boundary to use for encoding. This must not appear anywhere in the encoded data.
-    ///     - to: Buffer to write to.
+    ///     - to: Buffer type to write to.
     /// - throws: Any errors encoding the model with `Codable` or serializing the data.
     public func encode<E: Encodable, Body: MultipartPartBodyElement>(
         _ encodable: E,
@@ -58,6 +57,33 @@ public struct FormDataEncoder: Sendable {
         }
         writer._finish()
         return writer.getResult()
+    }
+
+    /// Encodes an `Encodable` item into some ``MultipartPartBodyElement`` using the supplied boundary.
+    ///
+    /// ```swift
+    /// let a = Foo(string: "a", int: 42, double: 3.14, array: [1, 2, 3])
+    /// var buffer = ByteBufferView()
+    /// let data = try FormDataEncoder().encode(a, boundary: "123", into: &buffer)
+    /// ```
+    ///
+    /// - parameters:
+    ///     - encodable: Generic `Encodable` item.
+    ///     - boundary: Multipart boundary to use for encoding. This must not appear anywhere in the encoded data.
+    ///     - buffer: Buffer to write to.
+    /// - throws: Any errors encoding the model with `Codable` or serializing the data.
+    public func encode<E: Encodable, Body: MultipartPartBodyElement>(
+        _ encodable: E,
+        boundary: String,
+        into buffer: inout Body
+    ) throws {
+        let parts: [MultipartPart<Body>] = try self.parts(from: encodable)
+        var writer = MemoryMultipartWriter<Body>(boundary: boundary, buffer: &buffer)
+        for part in parts {
+            writer._writePart(part)
+        }
+        writer._finish()
+        buffer = writer.getResult()
     }
 
     private func parts<E: Encodable, Body: MultipartPartBodyElement>(from encodable: E) throws -> [MultipartPart<Body>] {

--- a/Sources/MultipartKit/Writer/MemoryMultipartWriter.swift
+++ b/Sources/MultipartKit/Writer/MemoryMultipartWriter.swift
@@ -30,6 +30,18 @@ public struct MemoryMultipartWriter<OutboundBody: MultipartPartBodyElement>: Mul
         self.buffer = OutboundBody()
     }
 
+    /// Creates a new buffered multipart writer that writes into an existing buffer.
+    ///
+    /// - Parameters:
+    ///   - boundary: The boundary string to use for separating multipart parts.
+    ///   - buffer: An existing buffer to append into. The buffer is moved into the writer; the original is left empty.
+    @inlinable
+    public init(boundary: String, buffer: inout OutboundBody) {
+        self.boundary = boundary
+        self.buffer = OutboundBody()
+        swap(&self.buffer, &buffer)
+    }
+
     @inlinable
     public mutating func write(bytes: some Collection<UInt8> & Sendable) async throws {
         buffer.append(contentsOf: bytes)

--- a/Tests/MultipartKitTests/FormDataEncodingTests.swift
+++ b/Tests/MultipartKitTests/FormDataEncodingTests.swift
@@ -284,6 +284,25 @@ struct FormDataEncodingTests {
         #expect(try FormDataDecoder().decode(AllTypes.self, from: multipart, boundary: "-") == value)
     }
 
+    @Test("Encode into existing buffer")
+    func encodeIntoBuffer() throws {
+        struct Foo: Encodable {
+            var string: String
+            var int: Int
+        }
+
+        let expected = try FormDataEncoder().encode(Foo(string: "a", int: 42), boundary: "hello", to: [UInt8].self)
+
+        var buffer = [UInt8]()
+        try FormDataEncoder().encode(Foo(string: "a", int: 42), boundary: "hello", into: &buffer)
+        #expect(buffer == expected)
+
+        let prefix = Array("existing".utf8)
+        var prefixedBuffer = prefix
+        try FormDataEncoder().encode(Foo(string: "a", int: 42), boundary: "hello", into: &prefixedBuffer)
+        #expect(prefixedBuffer == prefix + expected)
+    }
+
     @Test("Encode simil-Vapor File type")
     func encodeSimilVaporFileType() async throws {
         struct User: Codable {


### PR DESCRIPTION
Add `FormDataEncoder.encode` method that takes an existing buffer to encode into
